### PR TITLE
filesystem is used, but was never a dep; remove cb_planner_msgs_srvs, which was not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ed_sensor_integration)
 
 find_package(catkin REQUIRED COMPONENTS
-  cb_planner_msgs_srvs
   ed
   geometry_msgs
   kdl_parser
   message_generation
+  tue_filesystem
   visualization_msgs
 )
 

--- a/package.xml
+++ b/package.xml
@@ -10,18 +10,18 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>cb_planner_msgs_srvs</build_depend>
   <build_depend>ed</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>tue_filesystem</build_depend>
   <build_depend>visualization_msgs</build_depend>
 
-  <run_depend>cb_planner_msgs_srvs</run_depend> <!-- TODO: get rid of this dep -->
   <run_depend>ed</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>kdl_parser</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>tue_filesystem</run_depend>
   <run_depend>visualization_msgs</run_depend>
 
 </package>


### PR DESCRIPTION
Has nothing to do with SDF, but branch name was chose so that it builded against the sdf branches of ED and tue_config. In which dependencies were removed.