### PR TITLE
Fix/buffer filling

### DIFF
--- a/ed_sensor_integration/include/ed/kinect/image_buffer.h
+++ b/ed_sensor_integration/include/ed/kinect/image_buffer.h
@@ -37,14 +37,14 @@ public:
     void initialize(const std::string& topic);
 
     /**
-     * @brief nextImage, Polls to see if there is a new image with transform. If not, returns false.
+     * @brief nextImage, Returns the most recent combination of image and transform, provided it is different from the previous time the function was called.
      *
      * Will remove the found image from the buffer.
      *
      * @param[in] root_frame, name of the tf frame with respect to which the sensor pose should be expressed
      * @param[out] image, rgbd image to write the next image to. Iff a next image is found
      * @param[out] sensor_pose, will be filled with the sensor pose corresponding to the next image. Iff a next image is found
-     * @return whether or not the next image is available
+     * @return whether or not a novel image is available
      */
     bool nextImage(const std::string& root_frame, rgbd::ImageConstPtr& image, geo::Pose3D& sensor_pose);
 

--- a/ed_sensor_integration/include/ed/kinect/image_buffer.h
+++ b/ed_sensor_integration/include/ed/kinect/image_buffer.h
@@ -16,6 +16,11 @@ namespace tf
 class TransformListener;
 }
 
+/**
+ * @brief The ImageBuffer class, provides a buffer to synchronise rgbd images with sensor positions.
+ * Images are stored until they are removed from the buffer or until a
+ * certain amount of time has passed
+ */
 class ImageBuffer
 {
 
@@ -25,12 +30,36 @@ public:
 
     ~ImageBuffer();
 
+    /**
+     * @brief initialize, configure the buffer
+     * @param topic, ros topic on which the rgbd images are published
+     */
     void initialize(const std::string& topic);
 
-    // Polls to see if there is a new image with transform. If not, returns false
+    /**
+     * @brief nextImage, Polls to see if there is a new image with transform. If not, returns false.
+     *
+     * Will remove the found image from the buffer.
+     *
+     * @param[in] root_frame, name of the tf frame with respect to which the sensor pose should be expressed
+     * @param[out] image, rgbd image to write the next image to. Iff a next image is found
+     * @param[out] sensor_pose, will be filled with the sensor pose corresponding to the next image. Iff a next image is found
+     * @return whether or not the next image is available
+     */
     bool nextImage(const std::string& root_frame, rgbd::ImageConstPtr& image, geo::Pose3D& sensor_pose);
 
-    // Blocks until a new image with transform is found. Returns false if no image or tf could be found within 'timeout_sec' seconds
+    //
+    /**
+     * @brief waitForRecentImage, Blocks until a new image with transform is found. Returns false if no image or tf could be found within 'timeout_sec' seconds
+     *
+     * Will remove the found image from the buffer.
+     *
+     * @param[out] root_frame, name of the tf frame with respect to which the sensor pose should be expressed
+     * @param[out] image, rgbd image to write the next image to. Iff a next image is found
+     * @param[out] sensor_pose, will be filled with the sensor pose corresponding to the next image. Iff a next image is found
+     * @param[in] timeout_sec, maximum duration to block.
+     * @return whether or not a next image was available within the timeout duration.
+     */
     bool waitForRecentImage(const std::string& root_frame, rgbd::ImageConstPtr& image, geo::Pose3D& sensor_pose, double timeout_sec);
 
 private:

--- a/ed_sensor_integration/src/kinect/image_buffer.cpp
+++ b/ed_sensor_integration/src/kinect/image_buffer.cpp
@@ -139,23 +139,16 @@ bool ImageBuffer::nextImage(const std::string& root_frame, rgbd::ImageConstPtr& 
                 ROS_WARN_STREAM("[IMAGE_BUFFER] Image too old to look-up tf: image timestamp = " << std::fixed
                                 << ros::Time(rgbd_image->getTimestamp()) << ": latest tf timestamp = " << std::fixed << latest_sensor_pose.stamp_);
             }
-
-            return false;
         }
         catch(tf::TransformException& exc)
         {
             ROS_ERROR_DELAYED_THROTTLE(10, "[IMAGE_BUFFER] Could not get latest sensor pose (probably because tf is still initializing): %s", ex.what());
             ROS_WARN("[IMAGE_BUFFER] Could not get latest sensor pose (probably because tf is still initializing): %s", ex.what());
-
-            // Discard images that have become too old
-            if (ros::Time::now() - ros::Time(rgbd_image->getTimestamp()) > ros::Duration(MAX_BUFFER_TIME))
-                image_buffer_.pop();
-
-            return false;
         }
         // Discard images that have become too old
         if (ros::Time::now() - ros::Time(rgbd_image->getTimestamp()) > ros::Duration(MAX_BUFFER_TIME))
             image_buffer_.pop();
+        return false;
     }
     catch(tf::TransformException& ex)
     {

--- a/ed_sensor_integration/src/kinect/image_buffer.cpp
+++ b/ed_sensor_integration/src/kinect/image_buffer.cpp
@@ -119,13 +119,13 @@ bool ImageBuffer::nextImage(const std::string& root_frame, rgbd::ImageConstPtr& 
         // Determine absolute kinect pose based on TF
         try
         {
-            tf::StampedTransform t_sensor_pose;
             tf_listener_->lookupTransform(root_frame, rgbd_image->getFrameId(), ros::Time(rgbd_image->getTimestamp()), t_sensor_pose);
         }
         catch(tf::TransformException& ex)
         {
             break;
         }
+
         // successfully found transform
         image_buffer_.pop();
         found = true;

--- a/ed_sensor_integration/src/kinect/image_buffer.cpp
+++ b/ed_sensor_integration/src/kinect/image_buffer.cpp
@@ -105,26 +105,6 @@ bool ImageBuffer::nextImage(const std::string& root_frame, rgbd::ImageConstPtr& 
     if (rgbd_image)
         image_buffer_.push(rgbd_image);
 
-    // Get latest sensor pose
-    try
-    {
-        tf::StampedTransform latest_sensor_pose;
-        tf_listener_->lookupTransform(root_frame, rgbd_image->getFrameId(), ros::Time(0), latest_sensor_pose);
-    }
-    catch(tf::TransformException& ex)
-    {
-        ROS_ERROR("[IMAGE_BUFFER] Could not get latest sensor pose (probably because tf is still initializing): %s", ex.what());
-        // prevent the buffer from overflowing
-        while(!image_buffer_.empty()) // loop to find the most recent match
-        {
-            rgbd_image = image_buffer_.front();
-            // Discard images that are out of date
-            if (ros::Time::now() - ros::Time(rgbd_image->getTimestamp()) > ros::Duration(MAX_BUFFER_TIME))
-                image_buffer_.pop();
-        }
-        return false;
-    }
-
     bool found = false;
     tf::StampedTransform t_sensor_pose;
 

--- a/ed_sensor_integration/src/kinect/image_buffer.cpp
+++ b/ed_sensor_integration/src/kinect/image_buffer.cpp
@@ -108,20 +108,21 @@ bool ImageBuffer::nextImage(const std::string& root_frame, rgbd::ImageConstPtr& 
     bool found = false;
     tf::StampedTransform t_sensor_pose;
 
-    while(!image_buffer_.empty()) // loop to find the most recent match
-    {
+    while (!image_buffer_.empty()) { // loop to find the most recent match
         rgbd_image = image_buffer_.front();
 
         // Discard images that are out of date
-        if (ros::Time::now() - ros::Time(rgbd_image->getTimestamp()) > ros::Duration(MAX_BUFFER_TIME))
+        if (ros::Time::now() - ros::Time(rgbd_image->getTimestamp()) > ros::Duration(MAX_BUFFER_TIME)) {
             image_buffer_.pop();
+            continue;
+        }
 
         // Determine absolute kinect pose based on TF
         try
         {
             tf_listener_->lookupTransform(root_frame, rgbd_image->getFrameId(), ros::Time(rgbd_image->getTimestamp()), t_sensor_pose);
         }
-        catch(tf::TransformException& ex)
+        catch (tf::TransformException& ex)
         {
             break;
         }
@@ -132,7 +133,7 @@ bool ImageBuffer::nextImage(const std::string& root_frame, rgbd::ImageConstPtr& 
         image = rgbd_image;
     }
 
-    if (found){
+    if (found) {
         geo::convert(t_sensor_pose, sensor_pose);
         // Convert from ROS coordinate frame to geolib coordinate frame
         sensor_pose.R = sensor_pose.R * geo::Matrix3(1, 0, 0, 0, -1, 0, 0, 0, -1);

--- a/ed_sensor_integration/src/kinect/image_buffer.cpp
+++ b/ed_sensor_integration/src/kinect/image_buffer.cpp
@@ -135,9 +135,9 @@ bool ImageBuffer::nextImage(const std::string& root_frame, rgbd::ImageConstPtr& 
             {
                 image_buffer_.pop();
                 ROS_ERROR_STREAM_DELAYED_THROTTLE(10, "[IMAGE_BUFFER] Image too old to look-up tf: image timestamp = " << std::fixed
-                                << ros::Time(rgbd_image->getTimestamp()));
+                                << ros::Time(rgbd_image->getTimestamp()) << ": latest tf timestamp = " << std::fixed << latest_sensor_pose.stamp_);
                 ROS_WARN_STREAM("[IMAGE_BUFFER] Image too old to look-up tf: image timestamp = " << std::fixed
-                                << ros::Time(rgbd_image->getTimestamp()));
+                                << ros::Time(rgbd_image->getTimestamp()) << ": latest tf timestamp = " << std::fixed << latest_sensor_pose.stamp_);
             }
 
             return false;
@@ -153,6 +153,9 @@ bool ImageBuffer::nextImage(const std::string& root_frame, rgbd::ImageConstPtr& 
 
             return false;
         }
+        // Discard images that have become too old
+        if (ros::Time::now() - ros::Time(rgbd_image->getTimestamp()) > ros::Duration(MAX_BUFFER_TIME))
+            image_buffer_.pop();
     }
     catch(tf::TransformException& ex)
     {


### PR DESCRIPTION
When tf is not available the image buffer used to fill up, which means it takes a long time for the thing to empty once it is back online. This fix sets a maximum time the images may spend in the buffer. If the images get too old they will be removed from the buffer. 