### PR TITLE
Add error msgs for timeouts

### DIFF
--- a/ed_sensor_integration/src/kinect/image_buffer.cpp
+++ b/ed_sensor_integration/src/kinect/image_buffer.cpp
@@ -61,7 +61,10 @@ bool ImageBuffer::waitForRecentImage(rgbd::ImageConstPtr& image, geo::Pose3D& se
         if (rgbd_image)
             break;
         else if (ros::Time::now() > t_end)
+        {
+            ROS_ERROR_NAMED("image_buffer", "[IMAGE_BUFFER] timeout waiting for image");
             return false;
+        }
         else
             ros::Duration(0.1).sleep();
     }
@@ -72,7 +75,10 @@ bool ImageBuffer::waitForRecentImage(rgbd::ImageConstPtr& image, geo::Pose3D& se
     // Wait until we have a tf
     if (!tf_listener_->canTransform(root_frame_, rgbd_image->getFrameId(), ros::Time(rgbd_image->getTimestamp()))) // Get the TF when it is available now
         if (!tf_listener_->waitForTransform(root_frame_, rgbd_image->getFrameId(), ros::Time(rgbd_image->getTimestamp()), t_end - ros::Time::now()))
+        {
+            ROS_ERROR_NAMED("image_buffer", "[IMAGE_BUFFER] timeout waiting for tf");
             return false;
+        }
 
     // - - - - - - - - - - - - - - - - - -
     // Calculate tf

--- a/ed_sensor_integration/src/kinect/image_buffer.cpp
+++ b/ed_sensor_integration/src/kinect/image_buffer.cpp
@@ -62,7 +62,7 @@ bool ImageBuffer::waitForRecentImage(rgbd::ImageConstPtr& image, geo::Pose3D& se
             break;
         else if (ros::Time::now() > t_end)
         {
-            ROS_ERROR_NAMED("image_buffer", "[IMAGE_BUFFER] timeout waiting for image");
+            ROS_ERROR_NAMED("image_buffer", "[IMAGE_BUFFER] timeout waiting for rgbd image");
             return false;
         }
         else


### PR DESCRIPTION
Looking at the log from the demo this morning. I only found the very unhelpful message: could not get image, but I could not find out what caused the wait-for-recent-image method to return false. Hopefully these messages will provide more insight in the future.